### PR TITLE
feat: add user roles

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ model User {
   email          String?   @unique
   emailVerified  DateTime?
   image          String?
+  role           String    @default("MEMBER")
   accounts       Account[]
   sessions       Session[]
   solvedProblems Problem[] @relation("SolvedProblems")

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -132,3 +132,24 @@ export const protectedProcedure = t.procedure
       },
     });
   });
+
+export const memberProcedure = protectedProcedure.use(async ({ ctx, next }) => {
+  if (ctx.session.user.role === "USER") {
+    throw new TRPCError({ code: "UNAUTHORIZED" });
+  }
+
+  return next({ ctx });
+});
+
+/**
+ * Admin procedure
+ *
+ * Only for admins registered in the database
+ */
+export const adminProcedure = memberProcedure.use(async ({ ctx, next }) => {
+  if (ctx.session.user.role !== "ADMIN") {
+    throw new TRPCError({ code: "UNAUTHORIZED" });
+  }
+
+  return next({ ctx });
+});

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -4,6 +4,8 @@ import GoogleProvider from "next-auth/providers/google";
 import { env } from "~/env";
 import { db } from "~/server/db";
 
+export type UserRole = "USER" | "MEMBER" | "ADMIN";
+
 /**
  * Module augmentation for `next-auth` types. Allows us to add custom properties to the `session`
  * object and keep type safety.
@@ -14,8 +16,8 @@ declare module "next-auth" {
   interface Session extends DefaultSession {
     user: {
       id: string;
+      role: UserRole;
       // ...other properties
-      // role: UserRole;
     } & DefaultSession["user"];
   }
 


### PR DESCRIPTION
Three roles set with the following idea:

- User (authenticated, but unprivileged)
- Member (authenticated and privileged; current default as only @tec.mx logins will be allowed)
- Admin (admin)